### PR TITLE
WIP: Prefetch HTML support, pt 1

### DIFF
--- a/Mods/index.js
+++ b/Mods/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const helmet = require('helmet');
+const bodyParser = require('body-parser');
+const morgan = require('morgan');
+
+const config = require('./config');
+const routes = require('./routes');
+
+const app = express();
+
+app.use(helmet());
+app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
+app.use(bodyParser.json({ extended: true, limit: "50mb" }));
+app.use(morgan('tiny'));
+
+app.use('/', routes);
+
+app.listen(config.server.port, () => {
+    console.log(`🚀Mercury Parser API listens on port ${config.server.port}`);
+});
+
+module.exports = app;

--- a/Mods/nginx.conf
+++ b/Mods/nginx.conf
@@ -1,0 +1,14 @@
+user  nginx;
+
+events {
+    worker_connections   1000;
+}
+http {
+    server {
+        client_max_body_size 50M;
+        listen 4000;
+        location / {
+          proxy_pass http://mercury-parser:3000;
+        }
+    }
+}

--- a/Mods/routes.js
+++ b/Mods/routes.js
@@ -1,0 +1,54 @@
+const Router = require('express').Router;
+const router = new Router();
+const Mercury = require('@postlight/mercury-parser');
+
+router.route('/').get((req, res) => {
+    res.json({
+        message: 'Welcome to 🚀mercury-parser-api API! Endpoint: /parser',
+    });
+});
+
+router.route('/parser').get(async (req, res) => {
+    let result = { message: 'No URL was provided' };
+    if (req.query.url) {
+        try {
+            const contentType = req.query.contentType || 'html';
+            let headers = new Object();
+            if (typeof req.query.headers !== 'undefined') {
+                headers = JSON.parse(req.query.headers);
+            }
+            result = await Mercury.parse(req.query.url, {
+                contentType,
+                headers,
+            });
+        } catch (error) {
+            result = { error: true, messages: error.message };
+        }
+    }
+    return res.json(result);
+});
+
+router.route('/parser').post(async (req, res) => {
+    let result = { message: 'No HTML was provided. Make sure you include a "html:" field in the JSON payload.' };
+    //console.log(`URL: ${req.body.url}`)
+    if (req.body.html) {
+        try {
+            const contentType = req.body.contentType || 'html';
+            let headers = new Object();
+            if (typeof req.query.headers !== 'undefined') {
+                headers = JSON.parse(req.body.headers);
+            }
+            //console.log(`HTML payload length: ${req.body.html.length}`)
+            result = await Mercury.parse(req.body.url || 'http://example.com/', {
+                contentType,
+                headers,
+                html: req.body.html,
+            });
+        } catch (error) {
+            result = { error: true, messages: error.message };
+        }
+    }
+    return res.json(result);
+});
+
+module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,18 @@ version: "3"
 services:
   mercury-parser:
     image: wangqiru/mercury-parser-api
+    volumes:
+    - ./Mods/routes.js:/app/routes.js
+    - ./Mods/index.js:/app/index.js
     expose:
       - "3000"
   nginx-load-balancer:
     image: nginx:latest
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./Mods/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
       - mercury-parser
     ports:
       - "4000:4000"
+
+

--- a/mercupy_parser/__init__.py
+++ b/mercupy_parser/__init__.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin as join
 
 import httpx
 from httpx import Response
+import requests
 
 
 def urljoin(*terms: str) -> str:
@@ -21,6 +22,32 @@ class Mercupy:
         api_endpoint = api_endpoint or os.environ.get("API_ENDPOINT", "http://0.0.0.0:4000")
         self.api_endpoint = urljoin(api_endpoint, "parser")
         self.verbose = verbose
+    
+    
+    def parse_prefetched(self, html: str, url: Optional[str]):
+        """
+        Send a pre-fetched HTML document to Mercury Parser. Sync-only at the moment.
+
+        Parameters
+        ----------
+        html : str
+            HTML document to parse. Converted to UTF-8 before sending.
+        url : Optional[str]
+            Optional URL where the document was fetched.
+            If None, Mercury will attempt inferring the URL (and usually succeeds).
+            Should that fail, URL will be set to 'http://example.com/'
+
+        Returns
+        -------
+        requests.Response
+            Response from the Mercury API, hopefully with the parsed article.
+
+        """
+        payload = {'html': html.encode('utf-8')}
+        if url:
+            payload['url'] = url
+        
+        return requests.post(self.api_endpoint, json=payload)
 
     def parser(self,
                urls: Union[str, List[str]],


### PR DESCRIPTION
Initial support for Mercury's pre-fetched HTML parsing feature. To parse a pre-fetched URL, use Mercupy.parse_prefetched(html: str) or POST a request to API_ENDPOINT with JSON body like {'html': html_string}.